### PR TITLE
Bump version from 1.3.1 to 1.3.2.

### DIFF
--- a/libs/react-numerics/package.json
+++ b/libs/react-numerics/package.json
@@ -29,5 +29,5 @@
     "type": "git",
     "url": "https://github.com/bitovi/react-numerics"
   },
-  "version": "1.3.1"
+  "version": "1.3.2"
 }


### PR DESCRIPTION
The publish action no longer updates the package version. 🤔 